### PR TITLE
added options to be passed on to Html->css

### DIFF
--- a/src/View/Helper/LessHelper.php
+++ b/src/View/Helper/LessHelper.php
@@ -134,9 +134,10 @@ class LessHelper extends Helper
      * @param  array  $options     Options in 'js' key will be pased to the less.js
      *                             parser and options in 'parser' will be passed to the less.php parser.
      * @param  array  $modify_vars Array of modify vars.
+     * @param  array  $options_for_css Array of options passed on to Html->css
      * @return string
      */
-    public function less($less = 'styles.less', array $options = [], array $modify_vars = [])
+    public function less($less = 'styles.less', array $options = [], array $modify_vars = [], array $options_for_css = [])
     {
         $options = $this->setOptions($options);
         $less    = (array)$less;
@@ -153,7 +154,7 @@ class LessHelper extends Helper
             if (!$options['cache']) {
                 return $this->Html->formatTemplate('style', ['content' => $css]);
             }
-            return $this->Html->css($css);
+            return $this->Html->css($css, $options_for_css);
         } catch (\Exception $e) {
             // env must be development in order to see errors on-screen
             if (Configure::read('debug')) {


### PR DESCRIPTION
Hi,

like discussed in #8, CakePdf needs full urls. So I added a parameter `options_for_css`
to be passed to `Html->css`.

I'm not this familiar with php, so I can't provide any tests.

regards
dieter
