### PR TITLE
Removing installer-name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
         "cakephp/cakephp": "~3.0",
         "oyejorge/less.php": "1.7.0.2"
     },
-    "extra": {
-        "installer-name": "Less"
-    },
     "autoload": {
         "psr-4": {
             "Less\\": "src"


### PR DESCRIPTION
This causes composer to install in a wrong path in some weird cases
